### PR TITLE
Adding additional error handing to defineOptions method.

### DIFF
--- a/src/Plugin/views/filter/EREFNodeTitles.php
+++ b/src/Plugin/views/filter/EREFNodeTitles.php
@@ -110,9 +110,12 @@ class EREFNodeTitles extends ManyToOne {
     //always exposed
     $options['exposed'] = array('default' => 1);
 
-    //get the relationships. set the first as the default
-    $relationship_field_names = array_keys($this->get_relationships);
-    $options['relationship'] = array('default' => $relationship_field_names[0], $this->get_relationships);
+    // only set the 'relationship' option if get_relationships returns an array.
+    if (is_array($this->get_relationships)) {
+      //get the relationships. set the first as the default
+      $relationship_field_names = array_keys($this->get_relationships);
+      $options['relationship'] = array('default' => $relationship_field_names[0], $this->get_relationships);
+    }
 
     //set the sort defaults. always numeric. compare with sort options private arrays to get value for sort
     $options['sort_order'] = array('default' => 0);


### PR DESCRIPTION
This PR addresses an issue I have with recurring warnings printing out on my View:

Warning: array_keys() expects parameter 1 to be array, null given in Drupal\entity_reference_exposed_filters\Plugin\views\filter\EREFNodeTitles->defineOptions() (line 114 of modules/custom/Entity-Reference-Exposed-Filters-master/src/Plugin/views/filter/EREFNodeTitles.php).
